### PR TITLE
Switch to yarn audit.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
-FROM alpine:3.8
+FROM alpine:edge
 
-RUN apk --no-cache add \
-    nodejs \
-    nodejs-npm \
-  && npm install -g \
-    nsp
+RUN apk --no-cache add yarn
 
 # Add node user/group with uid/gid 1000:
 # This is a workaround for boot2docker issue #581, see
@@ -13,6 +9,6 @@ RUN adduser -D -u 1000 node
 
 USER node
 
-ENTRYPOINT ["nsp"]
+ENTRYPOINT ["yarn"]
 
-CMD ["check"]
+CMD ["install", "--audit", "--ignore-scripts"]


### PR DESCRIPTION
## Why?

The NSP has been shut down: https://blog.npmjs.org/post/175511531085/the-node-security-platform-service-is-shutting

Today the servers finally shut down and we need to switch to something different, so we are able to deploy as it is a required check.

Options:

* [`npm audit`](https://docs.npmjs.com/cli/audit) starting with npm@6
* [`yarn audit`](https://yarnpkg.com/en/docs/cli/audit) starting with yarn@1.12.3

We use `yarn` throughout all our systems and don’t supply a `package-lock.json` we chose  the`yarn` option. 
`yarn audit` has just been added to v1.12.3 and that’s why we need `alpine:edge` here.

I would be happy if we had another solution but this seems to work for now.
Maybe all of this should be in another repository whatsoever.

Opinions? Ideas?

/cc @adashst